### PR TITLE
Add coordinate option for /nearest-place

### DIFF
--- a/LocalPackages/pve-only/place.msa
+++ b/LocalPackages/pve-only/place.msa
@@ -81,6 +81,9 @@
 
 	@args = parse_args($)
 	if (array_size(@args) == 3){
+		if (or(!is_numeric(@args[0]),!is_numeric(@args[1]),!is_numeric(@args[2]))){
+			die(color(LIGHT_PURPLE).'Usage: /nearest-place [<x> <y> <z>] (coordinates are optional')
+		}
 		foreach(@places, @place,
 			@dist = _distance(@args, @place['coord'])
 			if (@dist < @closest){


### PR DESCRIPTION
As requested in NerdNu/NerdBugs#110.

Usage:

/nearest-place: prints the nearest place to player location

/nearest-place x y z: prints the nearest place to the coordinates x,y,z
