### PR TITLE
/regions-at x y z & /nearest-place x z

### DIFF
--- a/LocalPackages/misc/region-info.msa
+++ b/LocalPackages/misc/region-info.msa
@@ -6,3 +6,12 @@
 *:'/regions-there' [$] = >>>
 	msg(color(YELLOW).'Regions located there: '.color(WHITE).array_implode(sk_regions_at(pcursor()), ', '))
 <<<
+
+*:'/regions-at' $x $y $z [$world] = >>>
+	msg(color(YELLOW).'Regions located at '.$x.' '.$y.' '.$z.'in '.if(equals($world,''),pworld(),$world).': '.color(WHITE).array_implode(sk_regions_at(array($x,$y,$z,if(equals($world,''),pworld(),$world))), ', '))
+<<<
+
+# mattman00000 anxiously awaits padmin approval for this part
+#*:'/regions-intersecting' $region [$world] = >>>
+#	msg(color(YELLOW).'Regions located there: '.color(WHITE).array_implode(sk_region_intersect(if(equals($world,''),pworld(),$world), $region), ', '))
+#<<<

--- a/LocalPackages/pve-only/place.msa
+++ b/LocalPackages/pve-only/place.msa
@@ -80,6 +80,7 @@
 	}
 
 	@args = parse_args($)
+	if(equals(array_size(@args),2),array_insert(@args,64,1))
 	if (array_size(@args) == 3){
 		if (or(!is_numeric(@args[0]),!is_numeric(@args[1]),!is_numeric(@args[2]))){
 			die(color(LIGHT_PURPLE).'Usage: /nearest-place [<x> <y> <z>] (coordinates are optional')


### PR DESCRIPTION
/regions-at x y z [world] allows for determining regions at arbitrary
coords, a corollary to /regions-here and /regions-there

/nearest-place x z now defaults y to 64, as I do almost every time I use
the command with coords

My first pull request, please be gentle <3
