### PR TITLE
Fancy colorful server alerts.

### DIFF
--- a/LocalPackages/misc/alerts.ms
+++ b/LocalPackages/misc/alerts.ms
@@ -2,8 +2,8 @@
 #	Return a non-null array of strings containing the alert messages.
 
 proc(_get_alerts,
-        @alerts = get_value('server.alerts.messages')
-        return (if (is_null(@alerts), array(), @alerts))
+        @alerts = get_value('server.alerts.messages');
+        return (if (is_null(@alerts), array(), @alerts));
 )
 
 
@@ -11,33 +11,33 @@ proc(_get_alerts,
 #	Start the timer callback that broadcasts alerts.
 
 proc(_start_alerts,
-	@seconds = get_value('server.alerts.seconds')
+	@seconds = get_value('server.alerts.seconds');
 	if (is_null(@seconds)) {
-		@seconds = 200
-		store_value('server.alerts.seconds', @seconds)
+		@seconds = 200;
+		store_value('server.alerts.seconds', @seconds);
 	}
 
 	@task = set_interval(@seconds * 1000, closure(
-		@alerts = _get_alerts()
+		@alerts = _get_alerts();
 		if (array_size(@alerts) == 0) {
 			# No messages to broadcast.
-			die()
+			die();
 		}
-		@index = get_value('server.alerts.index')
+		@index = get_value('server.alerts.index');
 		if (is_null(@index)) {
-			@index = 0
+			@index = 0;
 		}
-		@index = mod(@index, array_size(@alerts))
+		@index = mod(@index, array_size(@alerts));
 		if (is_array(@alerts[@index])) {
-			@a = @alerts[@index]
-			broadcast(color(@a[color]).'[Server] '.@a[msg])
+			@a = @alerts[@index];
+			broadcast(color(@a[color]).'[Server] '.@a[msg]);
 		} else {
-			broadcast(color(LIGHT_PURPLE).'[Server] '.@alerts[@index])
+			broadcast(color(LIGHT_PURPLE).'[Server] '.@alerts[@index]);
 		}
-		store_value('server.alerts.index', @index + 1)
+		store_value('server.alerts.index', @index + 1);
 	))
 
-	console('Starting alerts with task ID '.@task)
-	store_value('server.alerts.task', @task)
+	console('Starting alerts with task ID '.@task);
+	store_value('server.alerts.task', @task);
 )
 

--- a/LocalPackages/misc/alerts.msa
+++ b/LocalPackages/misc/alerts.msa
@@ -4,33 +4,33 @@
 #	Overall help for the /alert command.
 
 *:/alert = >>>
-	msg(color(LIGHT_PURPLE).'Usage:')
-	msg(color(LIGHT_PURPLE).'    /alert list')
-	msg(color(WHITE)       .'        List all broadcast messages.')
-	msg(color(LIGHT_PURPLE).'    /alert add <color> <message>')
-	msg(color(WHITE)       .'        Add the message to the broadcast rotation.')
-	msg(color(LIGHT_PURPLE).'    /alert remove <number>')
-	msg(color(WHITE)       .'        Remove a message by number.')
-	msg(color(LIGHT_PURPLE).'    /alert interval [<seconds>]')
-	msg(color(WHITE)       .'        Get or set the interval between broadcasts in seconds.')
-	msg(color(LIGHT_PURPLE).'    /alert load <file>')
-	msg(color(WHITE)       .'        Bulk load alerts from a text file. Use with caution.')
+	msg(color(LIGHT_PURPLE).'Usage:');
+	msg(color(LIGHT_PURPLE).'    /alert list');
+	msg(color(WHITE)       .'        List all broadcast messages.');
+	msg(color(LIGHT_PURPLE).'    /alert add <color> <message>');
+	msg(color(WHITE)       .'        Add the message to the broadcast rotation.');
+	msg(color(LIGHT_PURPLE).'    /alert remove <number>');
+	msg(color(WHITE)       .'        Remove a message by number.');
+	msg(color(LIGHT_PURPLE).'    /alert interval [<seconds>]');
+	msg(color(WHITE)       .'        Get or set the interval between broadcasts in seconds.');
+	msg(color(LIGHT_PURPLE).'    /alert load <file>');
+	msg(color(WHITE)       .'        Bulk load alerts from a text file. Use with caution.');
 <<<
 
 # /alert list
 #	List all of the alerts. Anyone can run this.
 
 *:/alert list = >>>
-	@alerts = _get_alerts()
-	msg(color(LIGHT_PURPLE).'There are '.array_size(@alerts).' alerts.')
-	@index = 1
+	@alerts = _get_alerts();
+	msg(color(LIGHT_PURPLE).'There are '.array_size(@alerts).' alerts.');
+	@index = 1;
 	foreach (@alerts, @a,
 		if (is_array(@a)) {
-			msg(color(@a[color]).'('.@index.') '.@a[msg])
+			msg(color(@a[color]).'('.@index.') '.@a[msg]);
 		} else {
-			msg(color(LIGHT_PURPLE).'('.@index.') '.@a)
+			msg(color(LIGHT_PURPLE).'('.@index.') '.@a);
 		}
-		inc(@index)
+		inc(@index);
 	)
 <<<
 
@@ -61,27 +61,27 @@
 	);
 
 	# Canonicalise color parameter
-	@colorName = to_lower(replace($alertColor, '_', ''))
+	@colorName = to_lower(replace($alertColor, '_', ''));
 
 	# Handle command without a specified color
 	if (array_index_exists(@validColors, @colorName)) {
-		@actualColor = @validColors[@colorName]
-		@alertMessage = $
+		@actualColor = @validColors[@colorName];
+		@alertMessage = $;
 	} else {
 		if ($alertColor[0] != '&') {
-			msg(color(RED).'"'.$alertColor.'" is not a valid color name. Defaulting to light purple.')
+			msg(color(RED).'"'.$alertColor.'" is not a valid color name. Defaulting to light purple.');
 		}
-		@actualColor = LIGHT_PURPLE
-		@alertMessage = $alertColor.' '.$
+		@actualColor = LIGHT_PURPLE;
+		@alertMessage = $alertColor.' '.$;
 	}
 
 	# Add the new alert
-	@newAlert = array(color: @actualColor, msg: colorize(@alertMessage))
-	array_push(@alerts, @newAlert)
+	@newAlert = array(color: @actualColor, msg: colorize(@alertMessage));
+	array_push(@alerts, @newAlert);
 
 	# Save the updated alerts
-	store_value('server.alerts.messages', @alerts)
-	msg(color(LIGHT_PURPLE).'Alert #'.array_size(@alerts).' added.')
+	store_value('server.alerts.messages', @alerts);
+	msg(color(LIGHT_PURPLE).'Alert #'.array_size(@alerts).' added.');
 	
 <<<
 
@@ -90,24 +90,24 @@
 #	An admin command to remove a specific alert by its 1-based /alert list index.
 
 *:/alert remove $number = >>>
-	_assertperm('admin')
-	@alerts = _get_alerts()
-	@number = $number
+	_assertperm('admin');
+	@alerts = _get_alerts();
+	@number = $number;
 	if (!is_integral(@number) || @number < 1 || @number > array_size(@alerts)) {
 		if (array_size(@alerts) == 0) {		
-			die(color(RED).'There are no alerts to remove.')
+			die(color(RED).'There are no alerts to remove.');
 		} else {
-			die(color(RED).'You must specify a number from 1 to '.array_size(@alerts).', inclusive.')
+			die(color(RED).'You must specify a number from 1 to '.array_size(@alerts).', inclusive.');
 		}
 	}
 
-	@removed = array_remove(@alerts, @number - 1)
+	@removed = array_remove(@alerts, @number - 1);
 	if (is_array(@removed)) {
-		msg(color(LIGHT_PURPLE).'Removed alert: '.@removed[msg])
+		msg(color(LIGHT_PURPLE).'Removed alert: '.@removed[msg]);
 	} else {
-		msg(color(LIGHT_PURPLE).'Removed alert: '.@removed)
+		msg(color(LIGHT_PURPLE).'Removed alert: '.@removed);
 	}
-	store_value('server.alerts.messages', @alerts)
+	store_value('server.alerts.messages', @alerts);
 <<<
 
 
@@ -115,36 +115,36 @@
 #	An admin command to show the interval between broadcast messages, in seconds.
 
 *:/alert interval = >>>
-	_assertperm('admin')
-        @seconds = get_value('server.alerts.seconds')
+	_assertperm('admin');
+        @seconds = get_value('server.alerts.seconds');
         if (is_null(@seconds)) {
-                @seconds = 200
-                store_value('server.alerts.seconds', @seconds)
+            @seconds = 200;
+            store_value('server.alerts.seconds', @seconds);
 	}
-	msg(color(LIGHT_PURPLE).'Alerts are broadcast every '.@seconds.' seconds.')
+	msg(color(LIGHT_PURPLE).'Alerts are broadcast every '.@seconds.' seconds.');
 <<<
 
 # /alert interval seconds
 #	An admin command to set the interval between broadcast messages, in seconds.
 
 *:/alert interval $seconds = >>>
-	_assertperm('admin')
-	@minInterval = 30
-	@seconds = $seconds
+	_assertperm('admin');
+	@minInterval = 30;
+	@seconds = $seconds;
 	if (! is_numeric(@seconds)) {
-		die(color(RED).'You must specify the interval in seconds as a number.')
+		die(color(RED).'You must specify the interval in seconds as a number.');
 	}
 	if (@seconds < @minInterval) {
-		die(color(RED).'The interval must be at least '.@minInterval.' seconds.')
+		die(color(RED).'The interval must be at least '.@minInterval.' seconds.');
 	}
 
-	@seconds = integer(@seconds)
-	store_value('server.alerts.seconds', @seconds)
+	@seconds = integer(@seconds);
+	store_value('server.alerts.seconds', @seconds);
 	try(
-		clear_task(get_value('server.alerts.task'))
+		clear_task(get_value('server.alerts.task'));
 	)
-	_start_alerts()
-	msg(color(LIGHT_PURPLE).'The alert broadcast interval was set to '.@seconds.' seconds.')
+	_start_alerts();
+	msg(color(LIGHT_PURPLE).'The alert broadcast interval was set to '.@seconds.' seconds.');
 <<<
 
 # /alert load <file>
@@ -152,33 +152,33 @@
 #	Each line of the file is added as a new alert, in addition to those already present.
 
 *:/alert load $file = >>>
-	_assertperm('admin')
-	@alerts = _get_alerts()
+	_assertperm('admin');
+	@alerts = _get_alerts();
 
 	# Guard against file disclosure. Disallow '/' in filenames. Require '.alerts' suffix.
-	@file = $file
+	@file = $file;
 	if (string_position(@file, '/') != -1) {
-		die(color(RED).'The file must be in the same directory as this script.')
+		die(color(RED).'The file must be in the same directory as this script.');
 	}
-	@suffix = '.alerts'
+	@suffix = '.alerts';
 	if (string_position(@file, @suffix) + length(@suffix) != length(@file)) {
-		die(color(RED),'The file name must end in ".alerts".')
+		die(color(RED),'The file name must end in ".alerts".');
 	}
 
 	# Read file. Add lines that aren't blank.
 	try(
-		@lines = split('\n', read(@file))
-		@count = 0
+		@lines = split('\n', read(@file));
+		@count = 0;
 		foreach(@lines, @message,
-			@message = trim(@message)
+			@message = trim(@message);
 			if (@message != '') {
-				inc(@count)
-				array_push(@alerts, @message)
+				inc(@count);
+				array_push(@alerts, @message);
 			}
 		)
-		store_value('server.alerts.messages', @alerts)
-		msg(color(LIGHT_PURPLE).'Added '.@count.' alerts.')
+		store_value('server.alerts.messages', @alerts);
+		msg(color(LIGHT_PURPLE).'Added '.@count.' alerts.');
 	,#catch
-		msg(color(RED).'That file could not be read.')
+		msg(color(RED).'That file could not be read.');
 	)
 <<<


### PR DESCRIPTION
So...I made an enhancement for the server alert system. It adds support for alternate colors (green and red besides the default purple). Although minor, this is something we've been looking to add to Survival for Reasons™.
- /alert add <message> is now /alert <color> <message>
- (Supported colors are purple, green and red)
- Short aliases: /alert-p, /alert-r, /alert-g
- Handles existing alerts that do not have an associated color

![screen shot 2014-05-29 at 5 14 13 pm](https://cloud.githubusercontent.com/assets/158727/3123792/456a855a-e776-11e3-8d96-f5196ef81c11.png)

This shouldn't affect anything for the other servers if they don't wish to use non-purple alerts (aside from having a shorter /alert-p <msg> command available), and it's all been thoroughly tested.
