### PR TITLE
Add /s command to italicise global chat, signifying sarcasm.

### DIFF
--- a/LocalPackages/misc/sarcasm.msa
+++ b/LocalPackages/misc/sarcasm.msa
@@ -3,5 +3,5 @@
 <<<
 
 *:/s $ = >>>
-	msg(color(ITALIC).$);
+	chat(color(ITALIC).$);
 <<<


### PR DESCRIPTION
![Indeed.](http://i.imgur.com/R1HDoO9.png)

Per the discussion on the forums, here: https://nerd.nu/forums/index.php?/topic/2494-sarcasm/

LocalPackages/msg/ was a candidate to hold this, but I'm pretty sure that package was obsoleted by NerdMessage, so LocalPackages/misc/ it is.
