### PR TITLE
Fix compiler warnings in newer builds

### DIFF
--- a/LocalPackages/BungeeCord/auto_include.ms
+++ b/LocalPackages/BungeeCord/auto_include.ms
@@ -1,4 +1,4 @@
-proc(_writeUTF, @ba, @str,
+proc _writeUTF(@ba, @str) {
 	@len = length(@str)
 	if (@len > 200) {
 		die('String too long')
@@ -6,9 +6,9 @@ proc(_writeUTF, @ba, @str,
 	ba_put_byte(@ba, 0)
 	ba_put_byte(@ba, @len)
 	ba_put_bytes(@ba, string_get_bytes(@str, 'ascii'))
-)
+}
 
-proc(_changeserver, @player, @server,
+proc _changeserver(@player, @server) {
 	@ba = byte_array()
 	_writeUTF(@ba, 'Connect')
 	_writeUTF(@ba, @server)
@@ -16,15 +16,15 @@ proc(_changeserver, @player, @server,
 	@servers = array('creative', 'pve', 'minigames', 'lobby')
 	if (array_contains(@servers, to_lower(@server)) && to_lower(@server) != import('sharedata.source'), 
 		unbind('bc-'.@player)
-		bind(player_quit, array(priority: normal, id: 'bc-'.@player), array(player: @player), @event, @server,
+		bind('player_quit', array(priority: 'normal', id: 'bc-'.@player), array(player: @player), @event, @server,
 			modify_event('message', color(yellow). @event['player'] . ' has switched to ' . @server)
 			unbind()
 		)
 	)
 	send_plugin_message(@player, 'BungeeCord', @ba)
-)
+}
 
-proc(_sendPluginMessage, @player, @channel, @messages,
+proc _sendPluginMessage(@player, @channel, @messages) {
 	if (@player != '~console') {
 		@ba = byte_array()
 		foreach (@messages, @message,
@@ -32,7 +32,7 @@ proc(_sendPluginMessage, @player, @channel, @messages,
 		)
 		send_plugin_message(@player, @channel, @ba)
 	}
-)
+}
 
 @mcb_tab_completer = closure(@alias, @sender, @args){
     @res = array();

--- a/LocalPackages/CHMail2/auto_include.ms
+++ b/LocalPackages/CHMail2/auto_include.ms
@@ -2,7 +2,7 @@
 /**
  * Retrieves the player's uuid from the mail database, or null if no player is known with that username
  */
-proc(_mail_get_puuid, @playerName){
+proc _mail_get_puuid(@playerName){
 	@res = query('mail', 'SELECT uuid FROM user WHERE last_username=? LIMIT 1', to_lower(@playerName));
 	if(length(@res) == 0){
 		return(null);
@@ -14,7 +14,7 @@ proc(_mail_get_puuid, @playerName){
 /**
  * Gets the last known username from the mail database, or null, if no player is known with that uuid
  */
-proc(_mail_get_username_from_uuid, @uuid){
+proc _mail_get_username_from_uuid(@uuid){
 	@res = query('mail', 'SELECT last_username FROM user WHERE uuid=?', @uuid);
 	if(length(@res) == 0){
 		return(null);
@@ -26,7 +26,7 @@ proc(_mail_get_username_from_uuid, @uuid){
 /**
  * Gets the last known display name from the mail database, or null, if no player is known with that uuid
  */
-proc(_mail_get_display_name_from_uuid, @uuid){
+proc _mail_get_display_name_from_uuid(@uuid){
 	@res = query('mail', 'SELECT last_display_name FROM user WHERE uuid=?', @uuid);
 	if(length(@res) == 0){
 		return(null);

--- a/LocalPackages/CHMail2/main.ms
+++ b/LocalPackages/CHMail2/main.ms
@@ -1,6 +1,6 @@
 
 
-bind(player_join, null, null, @event){
+bind('player_join', null, null, @event){
 	x_new_thread('mail_player_join', closure(){
 		// Sleep, so they are fully joined before we get their id.
 		sleep(1);

--- a/LocalPackages/CHMarquee/auto_include.ms
+++ b/LocalPackages/CHMarquee/auto_include.ms
@@ -1,5 +1,5 @@
 
-proc(_init_marquee, @name,
+proc _init_marquee(@name) {
 	if(!has_value('chmarquee.list')){
 		store_value('chmarquee.list', array())
 	}
@@ -8,18 +8,18 @@ proc(_init_marquee, @name,
 		array_push(@list, @name)
 		store_value('chmarquee.list', @list)
 	}
-)
+}
 
-proc(_check_marquee, @name,
+proc _check_marquee(@name) {
 	assign(@value, get_value('chmarquee.list'))
 	if(!is_array(@value) || !array_contains(@value, @name)){
 		return(false)
 	} else {
 		return(true)
 	}
-)
+}
 
-proc(_start_marquee, @name,
+proc _start_marquee(@name) {
 	#Stop the marquee if it's already started
 	marquee_stop(@name)
 	msg('Starting \''.@name.'\' marquee.')
@@ -58,13 +58,13 @@ proc(_start_marquee, @name,
 			_stop_marquee(@name)
 		)
 	))
-)
+}
 
-proc(_stop_marquee, @name,
+proc _stop_marquee(@name) {
 	marquee_stop(@name)
-)
+}
 
-proc(_remove_marquee, @name,
+proc _remove_marquee(@name) {
 	_stop_marquee(@name)
 	assign(@list, get_value('chmarquee.list'))
 	array_remove_values(@list, @name)
@@ -72,5 +72,5 @@ proc(_remove_marquee, @name,
 	foreach(array_keys(get_values('chmarquee.' . @name)), @key,
 		clear_value(@key)
 	)
-)
+}
 

--- a/LocalPackages/Chaos/suppress_death_messages.ms
+++ b/LocalPackages/Chaos/suppress_death_messages.ms
@@ -1,5 +1,5 @@
 
-bind(player_death, null, null, @e,
+bind('player_death', null, null, @e,
 	if(get_value('supress_death_messages')){
 		console('Death message suppressed: ' . @e['death_message'])
 		modify_event('death_message', null)

--- a/LocalPackages/ItemFrameMapBan/main.ms
+++ b/LocalPackages/ItemFrameMapBan/main.ms
@@ -1,6 +1,6 @@
 
 # Lol, I love one liners
-bind(player_interact_entity, null, null, @event,
+bind('player_interact_entity', null, null, @event,
 	if(@event['clicked'] == 'ITEM_FRAME' 
 		&& pinv(player(), null) != null 
 		&& (pinv(player(), null)['type'] == 395

--- a/LocalPackages/SessionTracker/main.ms
+++ b/LocalPackages/SessionTracker/main.ms
@@ -1,10 +1,10 @@
-bind(player_join, null, null, @event,
+bind('player_join', null, null, @event,
 	@session_number=get_value('session_number.'.player())+1
 	store_value('session_number.'.player(), @session_number)
 	store_value('session_start.'.player(), time())
 )
 
-bind(player_quit, null, null, @event,
+bind('player_quit', null, null, @event,
 	@session_number=get_value('session_number.'.player())
 	@session_start=get_value('session_start.'.player())
 	console('SessionTracker: '.player().','.@session_number.','.@session_start.','.(time()-@session_start))

--- a/LocalPackages/ShareData/auto_include.ms
+++ b/LocalPackages/ShareData/auto_include.ms
@@ -2,7 +2,7 @@
 /**
  * Stores a global shared value among the servers.
  */
-proc(_store_shared_value, @value,
+proc _store_shared_value(@value) {
 	@source = import('sharedata.source')
 	@data = get_value('sharedata.data')
 	if(!is_array(@data)){
@@ -11,13 +11,13 @@ proc(_store_shared_value, @value,
 	@piece = array(timestamp: time(), source: @source, data: @value)
 	array_push(@data, @piece)
 	store_value('sharedata.data', @data)
-)
+}
 
-proc(_bind_shared_value, @closure,
+proc _bind_shared_value(@closure) {
 	@binds = import('sharedata.binds')
 	if(!is_array(@binds)){
 		@binds = array()
 	}
 	array_push(@binds, @closure)
 	export('sharedata.binds', @binds)
-)
+}

--- a/LocalPackages/creative-only/auto_include.ms
+++ b/LocalPackages/creative-only/auto_include.ms
@@ -1,5 +1,5 @@
 
-proc(_ermagerd, @string,
+proc _ermagerd(@string) {
 	# Begin the transformations
 	@string = reg_replace('(?i)oo?r?', 'er', @string)
 	@string = reg_replace('a', 'er', @string)
@@ -8,9 +8,9 @@ proc(_ermagerd, @string,
 	@string = reg_replace('([^a-zA-Z])*?my', '$1ma', @string)
 	@string = reg_replace('[\\.,;]', '', @string) #Pfft, who needs punctuation
 	return(@string)
-)
+}
 
-proc(_effecthelp,
+proc _effecthelp() {
 	_assertperm('effect');
 	msg(color(GOLD) . 'Usage:');
 	msg(color(YELLOW) . '/effect clear ' . color(GOLD) . '- Clear all potion effects.');
@@ -21,7 +21,7 @@ proc(_effecthelp,
 	msg(color(GOLD) . '    <amplifier> - potion strength; 1, 2 etc.');
 	msg(color(GOLD) . '    <hide-particles> - if true, hide particles');
 	return (null);
-)
+}
 
 // Check the cooldown time of a command.
 //
@@ -32,7 +32,7 @@ proc(_effecthelp,
 //
 // returns: true if the cooldown is okay, or false if the timer is still
 //          running.
-proc(_checkCooldown, @commandName, @delay,
+proc _checkCooldown(@commandName, @delay) {
 	@varName = "cooldown." . @commandName . "." . player();
 	@cooldownTime = import(@varName);
 	@currentTime = time();
@@ -41,5 +41,5 @@ proc(_checkCooldown, @commandName, @delay,
 	}
 	export(@varName, @currentTime + @delay);
 	return(true);
-)
+}
 

--- a/LocalPackages/creative-only/suppress_death_messages.ms
+++ b/LocalPackages/creative-only/suppress_death_messages.ms
@@ -1,5 +1,5 @@
 
-bind(player_death, null, null, @e,
+bind('player_death', null, null, @e,
 	if(get_value('supress_death_messages')){
 		console('Death message suppressed: ' . @e['death_message'])
 		modify_event('death_message', null)

--- a/LocalPackages/games/koth.ms
+++ b/LocalPackages/games/koth.ms
@@ -3,7 +3,7 @@
 # Return the team ID (0 - 15) of the current King of the Hill - the team who has
 # placed their block in the scoring location. Return -1 if nobody holds that block.
 
-proc(_koth_king,
+proc _koth_king() {
 	@location = get_value('koth.location')
 	if (!is_null(@location)) {
 		@block = get_block_at(@location)
@@ -15,7 +15,7 @@ proc(_koth_king,
 		}
 	}
 	return (-1)
-)
+}
 
 
 # _koth_score_get()
@@ -23,14 +23,14 @@ proc(_koth_king,
 # Get the array of scores, which are the number of seconds that each team (0 - 15)
 # has held the scoring block.
 
-proc(_koth_score_get,
+proc _koth_score_get() {
 	@times = get_value('koth.times')
 	if (is_null(@times)) {
 		@times = array()
 		array_resize(@times, 16, 0)
 	}
 	return (@times)
-)
+}
 
 
 # _koth_score_clear()
@@ -38,19 +38,19 @@ proc(_koth_score_get,
 # Reset the accumulated time (score) for all teams to 0.
 # Return the initialised times array.
 
-proc(_koth_score_clear,
+proc _koth_score_clear() {
 	@times = array()
 	array_resize(@times, 16, 0)
 	store_value('koth.times', @times)
 	return (@times)
-)
+}
 
 
 # _koth_score_show()
 #
 # Show the current score.
 
-proc(_koth_score_show,
+proc _koth_score_show() {
 	# The chat color corresponding to a particular team ID (wool data value) from 0 - 15.
 	@COLOR = array(
 		color(WHITE), color(GOLD), color(LIGHT_PURPLE), color(BLUE), 
@@ -75,7 +75,7 @@ proc(_koth_score_show,
 		}
 	)
 	msg(@message)
-)
+}
 
 
 # _koth_reset()
@@ -83,7 +83,7 @@ proc(_koth_score_show,
 # Clear the accumulated scores.
 # If a team block (wool) is at the scoring location, set that block to air.
 
-proc(_koth_reset,
+proc _koth_reset() {
 	_koth_score_clear()
 	@team = _koth_king()
 	if (@team >= 0) {
@@ -91,19 +91,19 @@ proc(_koth_reset,
 		@location = get_value('koth.location')
 		set_block_at(@location, 0)
 	}
-)
+}
 
 
 # _koth_stop()
 #
 # Stop the scorekeeping task.
 
-proc(_koth_stop,
+proc _koth_stop() {
 	@task = get_value('koth.task')
 	if (! is_null(@task)) {
 		clear_task(@task)
 	}
-)	
+}
 
 
 # _koth_start()
@@ -112,7 +112,7 @@ proc(_koth_stop,
 # the 'koth.block' location.  Add to the score of whichever team has their 
 # wool colour there.
 
-proc(_koth_start,
+proc _koth_start() {
 	# Period between checks in seconds.
 	@CHECK_PERIOD = 1
 
@@ -126,4 +126,4 @@ proc(_koth_start,
 		}
 	))
 	store_value('koth.task', @task)
-)
+}

--- a/LocalPackages/global/EasySigns/auto_include.ms
+++ b/LocalPackages/global/EasySigns/auto_include.ms
@@ -6,7 +6,7 @@
 # if the arguments could not be parsed.
 # @args can be an array slice created with @args[cslice(first, last)].
 
-proc(_parse_location, @args,
+proc _parse_location(@args) {
 	if (array_size(@args) != 3 && array_size(@args) != 4) {
 		return ('The location must be of the form [<world>] <x> <y> <z>.')	
 	}
@@ -29,16 +29,16 @@ proc(_parse_location, @args,
 	}
 	
 	return (array(@args[@start], @args[@start+1], @args[@start+2], @world))
-)
+}
 
 /**
  * Changes the location array's new format into the old, expected format.
  */
-proc(_easy_sign_loc_conv, @location,
+proc _easy_sign_loc_conv(@location) {
 	@array = array()
 	@array[] = integer(@location['x'])
 	@array[] = integer(@location['y'])
 	@array[] = integer(@location['z'])
 	@array[] = @location['world']
 	return(@array)
-)
+}

--- a/LocalPackages/global/EasySigns/main.ms
+++ b/LocalPackages/global/EasySigns/main.ms
@@ -1,6 +1,6 @@
 
 export('easysign.signs', get_value('easysign.signs'))
-bind(player_interact, null, null, @e,
+bind('player_interact', null, null, @e,
 	if(array_index_exists(@e, 'location') && is_sign_at(@e['location'])){
 		@signdata = import('easysign.signs')
 		# Have to refactor the new format to the old format.
@@ -254,7 +254,7 @@ bind(player_interact, null, null, @e,
 							}
 						)
 					,'cart',
-						spawn_entity(MINECART, 1, @data['location'])
+						spawn_entity('MINECART', 1, @data['location'])
 					,'launch',
 						set_pvelocity(@data['x'], @data['y'], @data['z'])
 					,'randloc',

--- a/LocalPackages/global/FirstJoin/main.ms
+++ b/LocalPackages/global/FirstJoin/main.ms
@@ -1,5 +1,5 @@
 
-bind(player_join, null, null, @event,
+bind('player_join', null, null, @event,
 	if(@event['first_login']){
     #to add more books to firstjoin, just enter  "clear_value('cooldowns.book.'.player())" on line preceding your "run_cmd('/book ___')" line
 		run_cmd('/rulebook')

--- a/LocalPackages/global/UUID/auto_include.ms
+++ b/LocalPackages/global/UUID/auto_include.ms
@@ -2,7 +2,7 @@
 /**
  * Retrieves the player's uuid from the database, or null if no player is known with that username
  */
-proc(_get_puuid, @playerName) {
+proc _get_puuid(@playerName) {
 	@playerName = to_lower(strip_colors(@playerName));
 
 	if (ponline(@playerName)) {
@@ -34,7 +34,7 @@ proc(_get_puuid, @playerName) {
  * Gets the last known username from the database, or null, if no player is known with that UUID.
  * Hyphens are automatically stripped from the UUID to match the database contents.
  */
-proc(_get_username_from_uuid, @uuid) {
+proc _get_username_from_uuid(@uuid) {
 	@nameCache = import('nameCache');
 	@uuid = replace(@uuid, '-', '');
 
@@ -55,7 +55,7 @@ proc(_get_username_from_uuid, @uuid) {
 /**
  * Gets the last known display name from the database, or null, if no player is known with that uuid
  */
-proc(_get_display_name_from_uuid, @uuid){
+proc _get_display_name_from_uuid(@uuid){
 	@res = query('uuid', 'SELECT last_display_name FROM user WHERE uuid=?', @uuid);
 	if(length(@res) == 0){
 		return(null);

--- a/LocalPackages/global/UUID/main.ms
+++ b/LocalPackages/global/UUID/main.ms
@@ -5,7 +5,7 @@ export('nameCache', array())
 /**
  * Player login event to log the uuid and latest name
  */
-bind(player_login, null, null, @event,
+bind('player_login', null, null, @event,
 	x_new_thread('uuid_player_join', closure(){
 		// Sleep, so they are fully joined before we get their id.
 		sleep(1);

--- a/LocalPackages/global/misc/NoSpace.ms
+++ b/LocalPackages/global/misc/NoSpace.ms
@@ -3,7 +3,7 @@
  * in names cause many issues, so our solution is to just ban
  * the users at the git-go.
  */
-bind(player_login, null, null, @event){
+bind('player_login', null, null, @event){
 	if(reg_count('.*[ ]+.*', @event['player'])){
 		modify_event('result', 'KICK_BANNED');
 		modify_event('kickmsg', 'Unfortunately, usernames with spaces in them are not allowed on our servers.');

--- a/LocalPackages/home/warp.ms
+++ b/LocalPackages/home/warp.ms
@@ -65,7 +65,7 @@ if (_config_get('features.warp.enabled', true)) {
 
 				@color = 'white';
 				if (@count % 2 == 0) {
-					@color = gray;
+					@color = 'gray';
 				}
 
 				@count++;

--- a/LocalPackages/inv/auto_include.ms
+++ b/LocalPackages/inv/auto_include.ms
@@ -4,7 +4,7 @@
 #	If successful, return an array(@itemid, @metadata, @quantity), all entries numeric.
 #	Otherwise, return null.
 
-proc(_parseiargs, @input, 
+proc _parseiargs(@input) {
 	@m = reg_match('^([^ :]+)(:[0-9]+)?( [0-9]+)?$', @input)
 	if (array_index_exists(@m,0)) {
 		# CH docs tell lies. @itemid can be a string, e.g. '35:15' for 'blackwool'.
@@ -37,4 +37,4 @@ proc(_parseiargs, @input,
 	} else {
 		return (null)
 	}
-)
+}

--- a/LocalPackages/mail/auto_include.ms
+++ b/LocalPackages/mail/auto_include.ms
@@ -44,7 +44,7 @@ include('send.ms')
 include('senditem.ms')
 
 # Proc that will initialize multiline mail composition
-proc(_init_mail_chat, @recipient,
+proc _init_mail_chat(@recipient) {
     @mail_messages = import('mail.mail_messages')
     @recipients = import('mail.recipients')
     
@@ -61,7 +61,7 @@ proc(_init_mail_chat, @recipient,
         # If there aren't, go ahead and bind everything.
         
         # Event for accumulating chat messages to be sent back to the user upon completion of their mail message
-        bind(player_chat, 'mail-hold-back-chat', null, @event,
+        bind('player_chat', 'mail-hold-back-chat', null, @event,
         
             @mail_messages = import('mail.mail_messages')
             
@@ -74,9 +74,9 @@ proc(_init_mail_chat, @recipient,
             , # else
                 # If they aren't, first make sure that their chat doesn't go to the people composing mail.
                 foreach(array_keys(@mail_messages), @player,
-                    foreach(@event[recipients], @i,
-                        if(array_contains_ic(@event[recipients][@i], @player),
-                            array_remove(@event[recipients], @i)
+                    foreach(@event['recipients'], @i,
+                        if(array_contains_ic(@event['recipients'][@i], @player),
+                            array_remove(@event['recipients'], @i)
                         )
                     )
                 )
@@ -84,7 +84,7 @@ proc(_init_mail_chat, @recipient,
                 # Then, add their chat to each mail-composing player's hold queue.
                 @held_back_chat = import('mail.held_back_chat')
                 # The pinfo(4) here is to make sure the player's display name is used (instead of just player()) as it appears in the chat.
-                assign(@message, concat('<', pinfo(4), '> ', @event[message]))
+                assign(@message, concat('<', pinfo(4), '> ', @event['message']))
                 
                 foreach(array_keys(@mail_messages), @player,
                     assign(@held_back_chat[@player], @message)
@@ -96,7 +96,7 @@ proc(_init_mail_chat, @recipient,
         )
         
         # Event for composing multi-line mail messages
-        bind(player_chat, 'mail-compose', null, @event,
+        bind('player_chat', 'mail-compose', null, @event,
         
             @mail_messages = import('mail.mail_messages')
             @recipients = import('mail.recipients')
@@ -110,9 +110,9 @@ proc(_init_mail_chat, @recipient,
             , # else
                 # If they are, see what they typed.
                 # But first, make sure their chat message doesn't actually end up being a chat message. :P
-                assign(@event[recipients], null)
+                assign(@event['recipients'], null)
                 
-                switch(@event[message],
+                switch(@event['message'],
                     '-send',
                         # If they typed -send, send off the message!
                         _send_mail(player(), @recipients[to_lower(player())], @mail_messages[to_lower(player())], 'multiline-mail')
@@ -135,20 +135,20 @@ proc(_init_mail_chat, @recipient,
                         # Firstly, though, is there actually a mail message there yet?
                         if(not(@mail_messages[to_lower(player())]),
                             # If not, simply set the mail message to the chat message.
-                            assign(@mail_messages[to_lower(player())], @event[message])
+                            assign(@mail_messages[to_lower(player())], @event['message'])
                             
                         , # else
                             # Otherwise, append to the mail message instead.
-                            assign(@mail_messages[to_lower(player())], concat(@mail_messages[to_lower(player())], '\n', @event[message]))
+                            assign(@mail_messages[to_lower(player())], concat(@mail_messages[to_lower(player())], '\n', @event['message']))
                         )
                         
                         export('mail.mail_messages', @mail_messages)
                         
                         # Then, we give them back what they typed in the chat, for readability and mental organization.
-                        msg(color(7), @event[message])
+                        msg(color(7), @event['message'])
                     #
                 )
             )
         )
     )
-)
+}

--- a/LocalPackages/mail/dispatch.ms
+++ b/LocalPackages/mail/dispatch.ms
@@ -1,4 +1,4 @@
-proc(_mail_dispatch, @args,
+proc _mail_dispatch(@args) {
     # Parse the incoming command, depending on it's first
     # word.
     
@@ -85,7 +85,7 @@ proc(_mail_dispatch, @args,
                 if(equals(length(@args), 2),
                     # Push the special value "i1" onto the last arg if an amount wasn't specified.
                     # This way we send the whole stack if the item is "hand", or send 1 item if it's a name.
-                    array_push(@args, i1)
+                    array_push(@args, 'i1')
                 )
                 
                 if(_send_item(@args[0], @args[1], @args[2]),
@@ -191,4 +191,4 @@ proc(_mail_dispatch, @args,
         msg('- ', color(green), '/mail set [global] <option> <value>', color(white), ': set an option.')
         die(concat('- ', color(green), '/mail delete <id>', color(white), ': delete message <id>.'))
     )
-)
+}

--- a/LocalPackages/mail/read.ms
+++ b/LocalPackages/mail/read.ms
@@ -1,4 +1,4 @@
-proc(_accept_item, @i,
+proc _accept_item(@i) {
     # Accept an item a user has sent us. If the inv is filled and not all items are given,
     # save the rest for later.
     
@@ -46,9 +46,9 @@ proc(_accept_item, @i,
     , @ex,
         return(false)
     )
-)
+}
 
-proc(_read_index, @player, @page,
+proc _read_index(@player, @page) {
     assign(@inbox, _player_mail(@player))
     
     # Make sure the user really does have mail.
@@ -103,9 +103,9 @@ proc(_read_index, @player, @page,
         
         return(true)
     )
-)
+}
 
-proc(_read_mail_id, @player, @i,
+proc _read_mail_id(@player, @i) {
     # Read an individual mail.
     
     # Grab the users mailbox.
@@ -140,9 +140,9 @@ proc(_read_mail_id, @player, @i,
     )
     
     return(true)
-)
+}
 
-proc(_del_mail, @player, @id,
+proc _del_mail(@player, @id) {
     # Delete an individual item.
     
     # Get their mailbox
@@ -160,4 +160,4 @@ proc(_del_mail, @player, @id,
     , # else
         return(false)
     )
-)
+}

--- a/LocalPackages/mail/send.ms
+++ b/LocalPackages/mail/send.ms
@@ -1,4 +1,4 @@
-proc(_send_mail, @from, @to, @msg, assign(@type, null),
+proc _send_mail(@from, @to, @msg, @type = null) {
     # Send an abstract mail to someone.
     
     # Restrict permissions for this.
@@ -48,4 +48,4 @@ proc(_send_mail, @from, @to, @msg, assign(@type, null),
     )
     
     return(true)
-)
+}

--- a/LocalPackages/mail/senditem.ms
+++ b/LocalPackages/mail/senditem.ms
@@ -1,4 +1,4 @@
-proc(_send_hand_item, @target, @i, @count,
+proc _send_hand_item(@target, @i, @count) {
     if(player() == '~console',
         msg(color(red), 'You are console. You have no hand!')
         return(false)
@@ -58,9 +58,9 @@ proc(_send_hand_item, @target, @i, @count,
             )
         )
     )
-)
+}
 
-proc(_send_item, @target, @i, @c,
+proc _send_item(@target, @i, @c) {
     # Send items, removing them from this user's inventory.
     
     if(!has_permission(player(), 'chmail.send.item') &&
@@ -159,4 +159,4 @@ proc(_send_item, @target, @i, @c,
             return(false)
         )
     )
-)
+}

--- a/LocalPackages/mail/util.ms
+++ b/LocalPackages/mail/util.ms
@@ -1,7 +1,7 @@
 #export(assign(@_mail_debug, false))
 
 # Will return {{id, item},...} from @array for an @input of 'x,y-z,a'
-proc(_expand, @array, @input, assign(@decr, false),
+proc _expand(@array, @input, @decr = false) {
     # Too lazy to comment this right now.
     assign(@parts, reg_split(',', @input))
     assign(@retn, array()) # Returned object
@@ -41,9 +41,9 @@ proc(_expand, @array, @input, assign(@decr, false),
     )
     
     return(@retn)
-)
+}
 
-proc(_cooleddown, @time, @id,
+proc _cooleddown(@time, @id) {
     if(player() == '~console',
         return(true)
     )
@@ -60,10 +60,10 @@ proc(_cooleddown, @time, @id,
         store_value(@node, time())
         return(true)
     )
-)
+}
 
 # _page(array(1, 2, 3, 4, 5, 6, 7), 3, 1)
-proc(_page, @array, @itemsperpage, @p,
+proc _page(@array, @itemsperpage, @p) {
     # @page = 0
     assign(@page, subtract(@p, 1))
 
@@ -83,20 +83,20 @@ proc(_page, @array, @itemsperpage, @p,
     # @pages = @array[0..2] = {0, 1, 2}
     assign(@pages, @array[cslice(@firstitem, @lastitem)])
     return(@pages)
-)
+}
 
-proc(_player_mail, @player,
+proc _player_mail(@player) {
     assign(@mail, get_value(concat('chmail.inbox.', to_lower(strip_colors(@player)))))
     
     return(@mail)
-)
+}
 
-proc(_update_player_mail, @player, @mail,
+proc _update_player_mail(@player, @mail) {
     store_value(concat('chmail.inbox.', to_lower(strip_colors(@player))), @mail)
-)
+}
 
 # Proc for removing a player from the multiline-mail-composing list
-proc(_resolve_mail_list_removal, assign(@player, player()),
+proc _resolve_mail_list_removal(@player = player()) {
     
     @mail_messages = import('mail.mail_messages')
     @recipients = import('mail.recipients')
@@ -128,13 +128,13 @@ proc(_resolve_mail_list_removal, assign(@player, player()),
             export('mail.recipients', @recipients)
         )
     )
-)
+}
 
-proc(_get_p_or_def_option, @p, @n, assign(@default, null),
+proc _get_p_or_def_option(@p, @n, @default = null) {
     return(_get_poption(@p, @n, _get_option(@n, @default)))
-)
+}
 
-proc(_get_option, @n, assign(@default, null),
+proc _get_option(@n, @default = null) {
     assign(@name, to_lower(@n))
     assign(@id, concat('chmail.options.', @name))
     
@@ -145,23 +145,23 @@ proc(_get_option, @n, assign(@default, null),
     )
     
     return(@opt)
-)
+}
 
-proc(_set_option, @n, @value,
+proc _set_option(@n, @value) {
     assign(@name, to_lower(@n))
     assign(@id, concat('chmail.options.', @name))
     
     store_value(@id, @value)
-)
+}
 
-proc(_clear_option, @n,
+proc _clear_option(@n) {
     assign(@name, to_lower(@n))
     assign(@id, concat('chmail.options.', @name))
     
     clear_value(@id)
-)
+}
 
-proc(_get_poption, @player, @n, assign(@default, null),
+proc _get_poption(@player, @n, @default = null) {
     assign(@name, to_lower(@n))
     assign(@id, concat('chmail.poptions.', to_lower(strip_colors(@player)), '.', @name))
     
@@ -172,44 +172,44 @@ proc(_get_poption, @player, @n, assign(@default, null),
     )
     
     return(@opt)
-)
+}
 
-proc(_set_poption, @player, @n, @value,
+proc _set_poption(@player, @n, @value) {
     assign(@name, to_lower(@n))
     assign(@id, concat('chmail.poptions.', to_lower(strip_colors(@player)), '.', @name))
     
     store_value(@id, @value)
-)
+}
 
-proc(_clear_poption, @player, @n,
+proc _clear_poption(@player, @n) {
     assign(@name, to_lower(@n))
     assign(@id, concat('chmail.poptions.', to_lower(strip_colors(@player)), '.', @name))
     
     clear_value(@id)
-)
+}
 
-proc(_clear_poptions, @player,
+proc _clear_poptions(@player) {
     assign(@options, get_values(concat('chmail.poptions.', to_lower(strip_colors(@player)))))
     
     foreach(@options, @option,
         clear_value(@option)
     )
-)
+}
     
 
-proc(_clear_player_mail, @player,
+proc _clear_player_mail(@player) {
     clear_value(concat('chmail.inbox.', to_lower(strip_colors(@player))))
-)
+}
 
-proc(_clear_all_mail,
+proc _clear_all_mail() {
     assign(@inboxes, get_values(concat('chmail.inbox')))
     
     foreach(@inboxes, @inbox,
         clear_value(@inboxes)
     )
-)
+}
 
-proc(_item_name_to_value, @i,
+proc _item_name_to_value(@i) {
     # Translates an item's human-readable name, if present, into its
     # integer equivalent. Keeps damage values in mind.
     
@@ -233,12 +233,12 @@ proc(_item_name_to_value, @i,
     )
     
     return(@retn)
-)
+}
 
-proc(_mail_debug, @msg,
+proc _mail_debug(@msg) {
     @_mail_debug = import('mail._mail_debug')
     
     if(equals(@_mail_debug, true),
         console(@msg)
     )
-)
+}

--- a/LocalPackages/misc/auto_include.ms
+++ b/LocalPackages/misc/auto_include.ms
@@ -1,6 +1,6 @@
-proc(_convertcolors, @text,
+proc _convertcolors(@text) {
     return(reg_replace('&([0-9a-fA-F]{1})', concat(substr(color(0),0,1), '$1'), @text))
-)
+}
 
 
 

--- a/LocalPackages/misc/ban_beds.ms
+++ b/LocalPackages/misc/ban_beds.ms
@@ -3,7 +3,7 @@
  * This works around a minecraft bug that causes beds placed in the hell biome
  * to explode tnt like when right clicked with redstone.
  */
-bind(block_place, null, array(type: 26), @e,
+bind('block_place', null, array(type: 26), @e,
 	# Do not allow beds to be placed in the NETHER or THE_END.
 
 	@wenv = world_info(pworld())['environment']

--- a/LocalPackages/misc/seen.ms
+++ b/LocalPackages/misc/seen.ms
@@ -1,4 +1,4 @@
-bind(player_join, null, null, @event,
+bind('player_join', null, null, @event,
 	assign(@playerName, strip_colors(player()))
 	assign(@lowerName, to_lower(@playerName))
 	@ip = pinfo(@playerName, 3)

--- a/LocalPackages/modding/arena.msa
+++ b/LocalPackages/modding/arena.msa
@@ -13,7 +13,7 @@
             #sudo('//sel')
             
             store_value('arena_mode', '0')
-            sudo(/setwarp arena public false)
+            sudo('/setwarp arena public false')
             broadcast(concat(color(green), 'The arena is now closed! Get out!')),
         
         
@@ -27,7 +27,7 @@
             #sudo('//sel')
             
             store_value('arena_mode', '1')
-            sudo(/setwarp arena public true)
+            sudo('/setwarp arena public true')
             broadcast(concat(color(green), 'The arena is now open! Type /spawnme to be warped to the arena!')),
         
         

--- a/LocalPackages/modding/auto_include.ms
+++ b/LocalPackages/modding/auto_include.ms
@@ -2,14 +2,14 @@ include('players.ms')
 
 # Return true if the player has the specified potion effect, identified by numeric type ID.
 
-proc(_has_peffect, @player, @potionID,
+proc _has_peffect(@player, @potionID) {
 	foreach (get_peffect(@player), @effect,
-		if (@effect[id] == @potionID) {
+		if (@effect['id'] == @potionID) {
 			return (true)
 		}
 	)
 	return (false)
-)
+}
 
 
 # _lb_retention_days()
@@ -18,13 +18,12 @@ proc(_has_peffect, @player, @potionID,
 # This value is set as 'lb.retention.days' in plugins/CommandHelper/main.ms. 
 # If unspecified, it defaults to 21.
 
-proc(_lb_retention_days,
+proc _lb_retention_days() {
 	@days = import('lb.retention.days')
 	return (if(is_null(@days), 21, @days))
-)
+}
 
-proc(
-	_3d_distance, @arr1, @arr2,
+proc _3d_distance(@arr1, @arr2) {
 	return(
 		floor(
 			sqrt(
@@ -34,9 +33,9 @@ proc(
 			)
 		)
 	)
-)
+}
 
-proc(_add_flags, @region, @timeout, @tries, @owner,
+proc _add_flags(@region, @timeout, @tries, @owner) {
 	if(@tries < 1) {
 		msg(color(RED).'Default flags added unsuccessfully.')
 	} else {
@@ -49,4 +48,4 @@ proc(_add_flags, @region, @timeout, @tries, @owner,
 			})
 		}
 	}
-)
+}

--- a/LocalPackages/modding/ermagerd.ms
+++ b/LocalPackages/modding/ermagerd.ms
@@ -6,15 +6,15 @@
 export('ermagerd_players', @ermagerd_players)
 
 # See if a player is ermagerd
-proc(_is_ermagerd,
+proc _is_ermagerd() {
         @ermagerd_players = import('ermagerd_players')
         @ermagerd = array_index_exists(@ermagerd_players, '*')
                  || array_index_exists(@ermagerd_players, to_lower(player()));
         return(@ermagerd);
-)
+}
 
 # Ermagerd!
-proc(_ermagerd2, @string,
+proc _ermagerd2(@string) {
 	# Note. (?i) will ignore case
 	#       (?<!X) negative lookbehind
 	#       (?!X) negative lookahead
@@ -29,10 +29,10 @@ proc(_ermagerd2, @string,
         @string = reg_replace('(?i)my', 'MA', @string);
         @string = reg_replace('[\\.,;]', '', @string); #Pfft, who needs punctuation
         return(@string);
-)
+}
 
 # Filter chat
-bind(player_chat, null, null, @event,
+bind('player_chat', null, null, @event,
         if(!_is_ermagerd()) {
                 die();
         }
@@ -43,7 +43,7 @@ bind(player_chat, null, null, @event,
 )
 
 # Filter chat commands too! No Excape!
-bind(player_command, null, null, @event,
+bind('player_command', null, null, @event,
         @cmd = @event['prefix']
         if((@cmd == '/me' || @cmd == '/s') && _is_ermagerd()) {
                 @full_cmd = @event['command'];

--- a/LocalPackages/modding/players.ms
+++ b/LocalPackages/modding/players.ms
@@ -8,7 +8,7 @@
 #	*	If @target matches (inexactly) a player name, return his 0-based index.
 #	*	Otherwise, use the previously used index incremented by @step (+1 or -1).
 
-proc(_get_tp_index, @target, @step,
+proc _get_tp_index(@target, @step) {
 	if (is_numeric(@target)) {
 		return (integer(@target) - 1)
 	} else if (@target != '') {
@@ -22,13 +22,13 @@ proc(_get_tp_index, @target, @step,
 		@index = -1
 	}
 	return (@index + @step)
-)
+}
 
 
 # _tp_index(@index, @players)
 #	Teleport to @players[@index], with message and @index checking. Store updated index.
 
-proc(_tp_index, @index, @players,
+proc _tp_index(@index, @players) {
 	# Wrap around @index to a valid value in either direction.
 	@count = array_size(@players)
 	@index = mod(@count + @index, @count)
@@ -44,5 +44,5 @@ proc(_tp_index, @index, @players,
 		msg(color(GOLD).'Teleporting you to '.@player.' ('.(@index+1).' of '.@count.') at '.@niceLoc.'.')
 		set_ploc(@loc)
 	}
-)
+}
 

--- a/LocalPackages/modding/warn.ms
+++ b/LocalPackages/modding/warn.ms
@@ -1,4 +1,4 @@
-bind(player_join, null, null, @event,
+bind('player_join', null, null, @event,
     @warnings = get_value('warnings', _get_puuid(@event['player']))
     if(@warnings != null) {
         msg(color(GRAY).'---------------------------------------------')

--- a/LocalPackages/pve-only/auto_include.ms
+++ b/LocalPackages/pve-only/auto_include.ms
@@ -18,13 +18,13 @@ include('pets.ms')
 #	@lowers = array(1:, one, 2: two, 3: three)
 #	@uppers = _map(@lowers, closure(@s, to_upper(@s)))
 
-proc(_map_associative, @input, @f1,
+proc _map_associative(@input, @f1) {
 	@output = array(@input)
 	foreach (array_keys(@input), @key,
 		array_set(@output, @key, execute(@input[@key], @f1))
 	)
 	return (@output)
-)
+}
 
 
 # _map(@input, @f1)
@@ -35,7 +35,7 @@ proc(_map_associative, @input, @f1,
 # Example:
 #	@intCoords = _map(ploc[0..2], closure(@value, floor(@value)))
 
-proc(_map, @input, @f1,
+proc _map(@input, @f1) {
 	@output = array()
 	foreach (@input, @value,
 		console(@value)
@@ -43,4 +43,4 @@ proc(_map, @input, @f1,
 		array_push(@output, @f1Value)
 	)
 	return (@output)
-)
+}

--- a/LocalPackages/pve-only/dragon.ms
+++ b/LocalPackages/pve-only/dragon.ms
@@ -1,6 +1,6 @@
 # Prototype dragon fight changes
 
-bind(creature_spawn, null, null, @event,
+bind('creature_spawn', null, null, @event,
 	if(equals(@event['type'],"ENDER_DRAGON"),
 		set_timeout(1000, closure(
 			# Double the max health of the dragon when it spawns without setting its health.
@@ -9,7 +9,7 @@ bind(creature_spawn, null, null, @event,
 	)
 )
 
-bind(entity_damage_player, null, null, @event,
+bind('entity_damage_player', null, null, @event,
 	# Make the dragon breath have special effects
 	if(equals(@event['damager'],"AREA_EFFECT_CLOUD"),
 		if(equals(@event['location']['world'],"world_the_end"),
@@ -21,7 +21,7 @@ bind(entity_damage_player, null, null, @event,
 	)
 )
 
-bind(entity_damage, null, null, @event,
+bind('entity_damage', null, null, @event,
 	if(equals(@event['type'],"ENDER_DRAGON"),
 
 		# When Shot

--- a/LocalPackages/pve-only/maps.ms
+++ b/LocalPackages/pve-only/maps.ms
@@ -1,7 +1,7 @@
 # When right clicking on an item fram with a blank map that has a name which can be converted to an integer, convert the map into a completed map with an ID matching the name converted to an integer.
 
 
-bind(player_interact_entity, null, null, @event,
+bind('player_interact_entity', null, null, @event,
   # return right away if event is not a player clicking an item frame
   if(@event['clicked'] == "ITEM_FRAME") {
     @item=pinv(@event['player'],pheld_slot(@event['player']))

--- a/LocalPackages/pve-only/pets.ms
+++ b/LocalPackages/pve-only/pets.ms
@@ -5,9 +5,9 @@
 #
 #	Return the entity ID of the spawned horse.
 
-proc(_spawn_horse, @loc, @color, @pattern, 
-	@HORSE_COLORS = array(black, brown, chestnut, creamy, dark_brown, gray, white);
-	@HORSE_PATTERNS = array(none, socks, whitefield, white_dots, black_dots);
+proc _spawn_horse(@loc, @color, @pattern) {
+	@HORSE_COLORS = array('black', 'brown', 'chestnut', 'creamy', 'dark_brown', 'gray', 'white');
+	@HORSE_PATTERNS = array('none', 'socks', 'whitefield', 'white_dots', 'black_dots');
 
 	@color = if (is_null(@color), '', to_lower(@color));
 	@pattern = if (is_null(@pattern), '', to_lower(@pattern));
@@ -32,5 +32,4 @@ proc(_spawn_horse, @loc, @color, @pattern,
 	set_max_health(@id, 20);
 	set_mob_age(@id, 0);
 	return (@id);
-)
-
+}

--- a/LocalPackages/pve-only/suppress_death_messages.ms
+++ b/LocalPackages/pve-only/suppress_death_messages.ms
@@ -1,5 +1,5 @@
 
-bind(player_death, null, null, @e,
+bind('player_death', null, null, @e,
 	if(get_value('supress_death_messages')){
 		console('Death message suppressed: ' . @e['death_message'])
 		modify_event('death_message', null)

--- a/LocalPackages/pve-only/waypoints.ms
+++ b/LocalPackages/pve-only/waypoints.ms
@@ -1,12 +1,12 @@
-bind(player_death, null, null, @e,
+bind('player_death', null, null, @e,
 	try(
-		tmsg(@e[player], color(GOLD). 'Do ' . color(YELLOW) . '/wp death' . color(GOLD) . ' for your most recent death coordinates.');
+		tmsg(@e['player'], color(GOLD). 'Do ' . color(YELLOW) . '/wp death' . color(GOLD) . ' for your most recent death coordinates.');
 		@uuid = _get_puuid(player());
 		@waypoints = get_value('waypoints', @uuid);
 		if(@waypoints == null) {
 			@waypoints = array();
 		}
-		array_set(@waypoints, 'death', array('loc': @e[location], 'mode': private));
+		array_set(@waypoints, 'death', array('loc': @e['location'], 'mode': 'private'));
 		store_value('waypoints', @uuid, @waypoints);
 	, @ex,
 		console('Error adding death waypoint: ' . @ex);

--- a/LocalPackages/survival-only/PvPLogging.ms
+++ b/LocalPackages/survival-only/PvPLogging.ms
@@ -1,4 +1,4 @@
-bind(player_quit, null, null, @event,
+bind('player_quit', null, null, @event,
 	@loc = ploc(); // @event['location'];
 	console(@event['player'] . ' logged out at ([' . @loc['world'] . '] ' . @loc['x'] . ', ' . @loc['y'] . ', ' . @loc['z'] . ')');
 );

--- a/LocalPackages/trade/trade.ms
+++ b/LocalPackages/trade/trade.ms
@@ -1,4 +1,4 @@
-proc(_signencode, @data,
+proc _signencode(@data) {
 	assign(@new, '')
 	for(assign(@j, 0), lt(@j, length(@data)), inc(@j),
 		assign(@new, concat(@new, 
@@ -7,21 +7,24 @@ proc(_signencode, @data,
 				color(
 					integer(
 						substr(@data, @j, add(@j,1))))))))
-	return(@new))
+	return(@new)
+}
 
-proc(_signdecode, @data,
+proc _signdecode(@data) {
 	assign(@new, '')
 	for(assign(@j, 1), lt(@j, length(@data)), inc(@j, 2),
 		assign(@new, concat(@new,
 			if(equals(substr(@data, @j, add(@j,1)), ' '),
 				':',
 				substr(@data, @j, add(@j,1))))))
-	return(@new))
+	return(@new)
+}
 
-proc(_msg2, @text,
-	msg(concat(color(10), '[SIGN] ', color(15), @text)))
+proc _msg2(@text) {
+	msg(concat(color(10), '[SIGN] ', color(15), @text))
+}
 
-bind(player_interact, null, array(block: 68, button: 'right'), @event,
+bind('player_interact', null, array(block: 68, button: 'right'), @event,
 	assign(@text, get_sign_text(@event['location']))
 	#Check if it's a trade sign...
 	assign(@command, reg_match(concat(color(1),'\\[(.*)\\]'), @text[1]))

--- a/auto_include.ms
+++ b/auto_include.ms
@@ -1,4 +1,4 @@
-proc(_config_get, @name, @default,
+proc _config_get(@name, @default) {
 	@config = yml_decode(read('nerdch.yml'));
 
 	@path = split('.', @name)
@@ -17,9 +17,9 @@ proc(_config_get, @name, @default,
 	}
 
 	return(@default);
-)
+}
 
-proc(_assertperm, @name, @cmodetrumps,
+proc _assertperm(@name, @cmodetrumps) {
 	if(player() == '~console', return())
 	
 	if(pisop(), return())
@@ -30,10 +30,12 @@ proc(_assertperm, @name, @cmodetrumps,
 
 	msg(concat(color(red), 'You do not have permission to do this! [ap]'))
 	die()
-)
+}
 
-# mode = AND or OR, invalid modes become AND
-proc(_assertperms, @perms, @mode, @cmodetrumps,
+/**
+ * @param mode = AND or OR, invalid modes become AND
+ */ 
+proc _assertperms(@perms, @mode, @cmodetrumps) {
 	@mode = to_upper(@mode) != 'OR';
 	msg(@mode);
 
@@ -50,22 +52,22 @@ proc(_assertperms, @perms, @mode, @cmodetrumps,
 
 	msg(color(red) . 'You do not have permission to do this! [ap]');
 	die();
-)
+}
 
-proc(_assertbool, @bool,
+proc _assertbool(@bool) {
 	if (@bool) {
 		msg(color(red) . 'You do not have permission to do this! [ap]');
 		die();
 	}
-)
+}
 
-proc(_noperm,
+proc _noperm() {
 	msg(color(red) . 'You do not have permission to do this! [ap]');
 	die();
-)
+}
 
 #Gets the mods and admins on right now
-proc(_get_mods,
+proc _get_mods() {
 	assign(@mods, array())
 	assign(@ap, all_players())
 	foreach(@ap, @p,
@@ -81,10 +83,10 @@ proc(_get_mods,
 	#		array_push(@mods, @admin)
 	#)
 	return(@mods)
-)
+}
 
 #Gets just the admins on right now
-proc(_get_admins,
+proc _get_admins() {
 	assign(@admins, array())
 	assign(@ap, all_players())
 	foreach(@ap, @p,
@@ -98,9 +100,9 @@ proc(_get_admins,
 	   if(has_permission(@p, 'nerdch.level.admin'), array_push(@admins, @p))
 	)
 	return(@admins)
-)
+}
 
-proc(_get_chat_admins,
+proc _get_chat_admins() {
 	assign(@admins, array())
 	assign(@ap, all_players())
 	foreach(@ap, @p,
@@ -114,22 +116,22 @@ proc(_get_chat_admins,
 		if(has_permission(@p, 'nerdch.level.adminchat'), array_push(@admins, @p))
 	)
 	return(@admins)
-)
+}
 
 #Messages all mods and admins
-proc(_mbroadcast, @msg,
+proc _mbroadcast(@msg) {
 		foreach(_get_mods(), @m,
 				tmsg(@m, @msg)
 		)
 		/*foreach(_get_admins(), @a,
 				tmsg(@a, @msg)
 		)*/
-)
+}
 
-proc(_getonlinename, @name,
-	if(equals(@name, ''),
-		return(player()),
-	#else:
+proc _getonlinename(@name) {
+	if(equals(@name, '')) {
+		return(player());
+	} else {
 		try(
 			assign(@name2, player(@name))
 			return(if(equals(@name, '~console'), 'console', @name2)),
@@ -137,14 +139,16 @@ proc(_getonlinename, @name,
 			try(
 				return(player(concat(color(10), @name))),
 			@ex,
-				return(null)))))
+				return(null)))
+	}
+}
 
-proc(_contains, @needle, @haystack,
+proc _contains(@needle, @haystack) {
 		assign(@repl, replace(to_lower(@haystack), to_lower(@needle), ''))
 		#if(equals(to_lower(@haystack), to_lower(@repl)), return(false), return(true))
 		return(not(equals_ic(@haystack, @repl)))
-)
-proc(_kit, @name, 
+}
+proc _kit(@name) {
 	if(equals(@name, ''),
 		assign(@kits, array())
 		foreach(reg_split('\n', read('kits.txt')), @l,
@@ -168,4 +172,5 @@ proc(_kit, @name,
 					#else:
 						break()))))
 		if(equals(@found, 0),
-			msg(concat(color(red), 'Kit not found!')))))
+			msg(concat(color(red), 'Kit not found!'))))
+}


### PR DESCRIPTION
This is a 'light touch' change, in that I didn't change most of the older syntax other than the places that will cause problems in future builds. For the most part, this manifests itself in using the new syntax for procs (`proc _name() {}` instead of `proc(_name, ...)`) quoting event names in binds, as well as removing a few other uses of bare strings here and there. These eliminate all the compiler warnings in current builds of CH, but should be backwards compatible with all builds in the past 5 years or whatever. There are a few compile errors which I didn't fix, because presumably you are still on an older build in which these work, and fixing them for modern CH will break it for older CH. However, there are only a handful of these, so upgrading in the future should be much easier now for you.